### PR TITLE
fix: minor changes in the INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,11 +12,12 @@
    conda create -n vlnbert python=3.6
    conda activate vlnbert
    ```
-3. Install NVIDIA Apex by following their [quick start](https://github.com/nvidia/apex#quick-start) instructions.
-4. Install additional requirements:
+3. Install additional requirements:
    ```
    pip install -r requirements.txt
    ```
+4. Install NVIDIA Apex by following their [quick start](https://github.com/nvidia/apex#quick-start) instructions.
+
 
 ## Data Preprocessing
 
@@ -25,7 +26,7 @@
    required configuration files is to run the following command:
 
    ```
-   python scripts/download-auxilary-data.py
+   python scripts/download-auxiliary-data.py
    ```
 
 2. Next, precompute image features using


### PR DESCRIPTION
fix typo + order between NVIDIA apex and requirements, since the installation of apex depends on the version of pytorch.
By the way, the latest commit from apex does not support pytorch 1.2.0 anymore. I used commit `93cabd5`